### PR TITLE
Facebook app id 2016.03.01 bhanson

### DIFF
--- a/OneSeoPlugin.php
+++ b/OneSeoPlugin.php
@@ -31,6 +31,9 @@ class OneSeoPlugin extends BasePlugin
         return array(
           'titleDividerCharacter' => array(
               AttributeType::String, 'label' => 'Meta Title Divider Character', 'default' => '–'
+          ),
+          'facebookAppId' => array(
+            AttributeType::String, 'label' => 'Facebook App ID'
           )
         );
     }
@@ -50,7 +53,7 @@ class OneSeoPlugin extends BasePlugin
     public function init()
     {
       craft()->templates->hook('getSeoMeta', function(&$context)
-      {   
+      {
           if (isset($context['customMetaTitle']))
           {
             craft()->oneSeo_meta->setMetaTitle($context['customMetaTitle']);
@@ -60,7 +63,7 @@ class OneSeoPlugin extends BasePlugin
           {
             craft()->oneSeo_meta->setMetaDescription($context['customMetaDescription']);
           }
-          
+
           if (isset($context['customMetaImage']))
           {
             craft()->oneSeo_meta->setMetaImage($context['customMetaImage']);

--- a/templates/meta.html
+++ b/templates/meta.html
@@ -7,7 +7,9 @@
 {% if image is defined %}<meta property="og:image" content="{{ image }}" />{% endif %}
 <meta property="og:url" content="{{ url }}" />
 {% if description is defined %}<meta property="og:description" content="{{ description }}" />{% endif %}
-<meta property="fb:admins" content="USER_ID" />
+{% if craft.oneseo.facebookAppId | length  %}
+  <meta property="fb:app_id" content="{{ craft.oneseo.facebookAppId }}" />
+{% endif %}
 
 <meta name="twitter:card" content="summary">
 <meta name="twitter:url" content="{{ url }}">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,3 +23,19 @@
     }) }}
   </div>
 </div>
+
+<div class="field">
+  <div class="heading">
+    <label for="titleDividerCharacter">Facebook App ID</label>
+    <div class="instructions">
+      <p>If you register a Facebook app at <a href="https://developers.facebook.com">the Facebook Developers page</a> we will insert an additional tag that allows you to take advantage of <a href="https://developers.facebook.com/docs/platforminsights/domains">Facebook Domain Insights</a></p>
+    </div>
+  </div>
+  <div class="input">
+    {{ forms.text({
+        id:     "facebookAppId",
+        name:   "facebookAppId",
+        value:  settings.facebookAppId
+    }) }}
+  </div>
+</div>

--- a/variables/OneSeoVariable.php
+++ b/variables/OneSeoVariable.php
@@ -8,7 +8,7 @@ class OneSeoVariable
      * @return string
      */
     public function meta()
-    {   
+    {
         $pluginSettings = craft()->plugins->getPlugin('oneSeo')->getSettings();
 
         $metaData = [
@@ -54,7 +54,7 @@ class OneSeoVariable
                     }
                 }
             }
-            
+
             // Set URL
             $metaData['url'] = $element->url;
         }
@@ -73,7 +73,7 @@ class OneSeoVariable
         if ($customTemplateImage = craft()->oneSeo_meta->getMetaImage()) {
             $metaData['image'] = $customTemplateImage;
         }
-        
+
         // Concatenate the full title
         if ($metaData['pageTitle'] != craft()->siteName) {
           $metaData['pageTitle'] = $metaData['pageTitle'] . $dividerChar . craft()->siteName;
@@ -86,5 +86,11 @@ class OneSeoVariable
         $html = craft()->templates->render('meta', $metaData);
         craft()->path->setTemplatesPath($originalPath);
         echo $html;
+    }
+
+    public function facebookAppId()
+    {
+      $pluginSettings = craft()->plugins->getPlugin('oneSeo')->getSettings();
+      return $pluginSettings->facebookAppId;
     }
 }


### PR DESCRIPTION
Removes the `fb:admins` tag in favor of `fb:app_id` tag.

This also adds a setting field to the plugin for users to input their app_id from Facebook. If they don't add it we simply ignore the tag.

This will have to be merged and a new tag created in order to test / fix https://www.pivotaltracker.com/story/show/114521467